### PR TITLE
Integrate database search

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -890,6 +890,28 @@ export async function getAllPlayers(
   }
 }
 
+// Search players by name or team
+export async function searchPlayers(
+  searchQuery,
+  type = "pro",
+  limit = 20
+) {
+  try {
+    const allPlayers = await getAllPlayers(type, 1, 200, {});
+    if (!allPlayers) return [];
+    const query = searchQuery.toLowerCase();
+    const filtered = allPlayers.filter(
+      (p) =>
+        p.name.toLowerCase().includes(query) ||
+        (p.team && p.team.toLowerCase().includes(query))
+    );
+    return filtered.slice(0, limit);
+  } catch (error) {
+    console.error("Error searching players:", error);
+    return [];
+  }
+}
+
 export async function getAllMaps() {
   try {
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- connect search results page with database
- load demos and players from Supabase
- randomize results using fetched data while keeping mockups for others
- expose `searchPlayers` helper in Supabase library

## Testing
- `npx eslint src/app/search/page.jsx` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8be1cedc8331a6c4231c1f65b887