### PR TITLE
Add persistent sidebar navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,21 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --brand-yellow: #FBBF24;
+  --gray-900: #181a20;
+  --gray-800: #23272f;
+  --gray-700: #374151;
+}
+
+/* Brand utility classes */
+.text-brand-yellow {
+  color: var(--brand-yellow);
+}
+.bg-brand-yellow {
+  background-color: var(--brand-yellow);
+}
+.border-brand-yellow {
+  border-color: var(--brand-yellow);
 }
 
 @theme inline {
@@ -22,6 +37,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
+  font-family: var(--font-sans);
 }
 
 /* Global cursor styles */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,15 @@
 .border-brand-yellow {
   border-color: var(--brand-yellow);
 }
+.hover\:text-brand-yellow:hover {
+  color: var(--brand-yellow);
+}
+.hover\:bg-brand-yellow:hover {
+  background-color: var(--brand-yellow);
+}
+.hover\:border-brand-yellow:hover {
+  border-color: var(--brand-yellow);
+}
 
 @theme inline {
   --color-background: var(--background);

--- a/src/app/maps/[mapName]/page.jsx
+++ b/src/app/maps/[mapName]/page.jsx
@@ -588,7 +588,7 @@ const MapPage = ({ params }) => {
     return (
       <div className="min-h-screen bg-gradient-to-br from-gray-700 via-gray-800 to-gray-900 flex items-center justify-center">
         <div className="text-center">
-          <div className="w-16 h-16 border-4 border-gray-600 border-t-yellow-400 rounded-full animate-spin mx-auto mb-4"></div>
+          <div className="w-16 h-16 border-4 border-gray-600 border-t-brand-yellow rounded-full animate-spin mx-auto mb-4"></div>
           <p className="text-white text-lg font-medium">Loading map data...</p>
         </div>
       </div>
@@ -645,7 +645,7 @@ const MapPage = ({ params }) => {
         </div>
 
         {/* Content */}
-        <div className="relative z-30 container mx-auto h-full flex items-center justify-center px-6">
+        <div className="relative z-30 container mx-auto h-full flex items-center justify-center px-4 md:px-6">
           <div className="text-center">
             <HeroHeading>{formattedMapName}</HeroHeading>
           </div>
@@ -657,7 +657,7 @@ const MapPage = ({ params }) => {
 
       {/* Tab Navigation */}
       <div className="bg-gray-900 border-b border-gray-800 sticky top-16 z-30">
-        <div className="container mx-auto px-6">
+        <div className="container mx-auto px-4 md:px-6">
           <div className="flex overflow-x-auto custom-scrollbar">
             <ToggleButton
               active={activeTab === "callouts"}
@@ -689,14 +689,14 @@ const MapPage = ({ params }) => {
 
       {/* Main Content */}
       <main
-        className="container mx-auto px-6 py-12 bg-pattern"
+        className="container mx-auto px-4 md:px-6 py-12 bg-pattern"
         ref={mapSectionRef}
       >
         {/* Callouts Tab */}
         {activeTab === "callouts" && (
           <div>
             <h2 className="text-2xl font-bold text-white mb-6">
-              <span className="border-l-4 border-yellow-400 pl-3 py-1">
+              <span className="border-l-4 border-brand-yellow pl-3 py-1">
                 Callouts
               </span>
             </h2>
@@ -717,7 +717,7 @@ const MapPage = ({ params }) => {
         {activeTab === "positions" && (
           <div>
             <h2 className="text-2xl font-bold text-white mb-6">
-              <span className="border-l-4 border-yellow-400 pl-3 py-1">
+              <span className="border-l-4 border-brand-yellow pl-3 py-1">
                 Positions
               </span>
             </h2>
@@ -791,7 +791,7 @@ const MapPage = ({ params }) => {
           <div>
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-2xl font-bold text-white">
-                <span className="border-l-4 border-yellow-400 pl-3 py-1">
+                <span className="border-l-4 border-brand-yellow pl-3 py-1">
                   {formattedMapName}'s All POVs
                 </span>
               </h2>
@@ -817,7 +817,7 @@ const MapPage = ({ params }) => {
         {activeTab === "strategies" && (
           <div>
             <h2 className="text-2xl font-bold text-white mb-6">
-              <span className="border-l-4 border-yellow-400 pl-3 py-1">
+              <span className="border-l-4 border-brand-yellow pl-3 py-1">
                 Strategies
               </span>
             </h2>

--- a/src/app/maps/page.jsx
+++ b/src/app/maps/page.jsx
@@ -263,7 +263,7 @@ const MapsIndex = () => {
     return (
       <div className="min-h-screen bg-gradient-to-br from-gray-700 via-gray-800 to-gray-900 flex items-center justify-center">
         <div className="text-center">
-          <div className="w-16 h-16 border-4 border-gray-600 border-t-yellow-400 rounded-full animate-spin mx-auto mb-4"></div>
+          <div className="w-16 h-16 border-4 border-gray-600 border-t-brand-yellow rounded-full animate-spin mx-auto mb-4"></div>
           <p className="text-white text-lg font-medium">Loading maps...</p>
         </div>
       </div>
@@ -282,7 +282,7 @@ const MapsIndex = () => {
       {/* Hero Header */}
       <div className="relative py-16 bg-gradient-to-b from-gray-800 to-gray-900">
         <div className="absolute inset-0 bg-yellow-400/5 mix-blend-overlay"></div>
-        <div className="container mx-auto px-6 text-center">
+        <div className="container mx-auto px-4 md:px-6 text-center">
           <HeroHeading>CS2 Maps</HeroHeading>
           <p className="text-gray-300 max-w-2xl mx-auto mb-8">
             Browse all official CS2 maps and watch POV demos for specific
@@ -297,14 +297,14 @@ const MapsIndex = () => {
                 placeholder="Search maps or positions..."
                 value={searchQuery}
                 onChange={handleSearchChange}
-                className="w-full p-4 pl-12 bg-gray-800 border border-gray-700 rounded-xl text-white focus:outline-none focus:border-yellow-400"
+                className="w-full p-4 pl-12 bg-gray-800 border border-gray-700 rounded-xl text-white focus:outline-none focus:border-brand-yellow"
               />
               <Search className="absolute left-4 top-4 h-5 w-5 text-gray-400" />
 
               <button
                 type="button"
                 onClick={() => setIsFilterModalOpen(true)}
-                className="absolute right-3 top-3 p-1 bg-gray-700 hover:bg-yellow-400 hover:text-gray-900 rounded-lg transition-colors"
+                className="absolute right-3 top-3 p-1 bg-gray-700 hover:bg-brand-yellow hover:text-gray-900 rounded-lg transition-colors"
               >
                 <Filter className="h-5 w-5" />
               </button>
@@ -314,7 +314,7 @@ const MapsIndex = () => {
       </div>
 
       {/* Main Content */}
-      <main className="container mx-auto px-6 py-12">
+      <main className="container mx-auto px-4 md:px-6 py-12">
         {/* Map Grid */}
         {filteredMaps.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
@@ -324,7 +324,7 @@ const MapsIndex = () => {
                 href={`/maps/${map.name.toLowerCase()}`}
                 className="block group"
               >
-                <div className="relative flex-shrink-0 overflow-hidden rounded-xl transition-all duration-300 hover:scale-105 bg-gradient-to-br from-gray-800 to-gray-900 shadow-lg border border-gray-700 hover:border-yellow-400/30 h-full">
+                <div className="relative flex-shrink-0 overflow-hidden rounded-xl transition-all duration-300 hover:scale-105 bg-gradient-to-br from-gray-800 to-gray-900 shadow-lg border border-gray-700 hover:border-brand-yellow h-full">
                   {/* Map Image */}
                   <div className="relative h-48 overflow-hidden">
                     <img
@@ -336,7 +336,7 @@ const MapsIndex = () => {
 
                     {/* Map name overlay */}
                     <div className="absolute bottom-0 left-0 right-0 p-4">
-                      <h2 className="text-white font-bold text-xl group-hover:text-yellow-400 transition-colors">
+                      <h2 className="text-white font-bold text-xl group-hover:text-brand-yellow transition-colors">
                         {map.name}
                       </h2>
                     </div>
@@ -349,7 +349,7 @@ const MapsIndex = () => {
                     </p>
 
                     <div className="flex justify-between items-center mb-3">
-                      <div className="flex items-center text-yellow-400">
+                      <div className="flex items-center text-brand-yellow">
                         <MapPin className="h-4 w-4 mr-1" />
                         <span className="text-sm font-medium">
                           {map.positions.length} positions
@@ -367,7 +367,7 @@ const MapsIndex = () => {
                       {map.positions.slice(0, 3).map((position, idx) => (
                         <span
                           key={idx}
-                          className="text-xs bg-gray-700 px-2 py-0.5 rounded hover:bg-yellow-400 hover:text-gray-900 transition-colors"
+                          className="text-xs bg-gray-700 px-2 py-0.5 rounded hover:bg-brand-yellow hover:text-gray-900 transition-colors"
                         >
                           {position}
                         </span>
@@ -380,7 +380,7 @@ const MapsIndex = () => {
                     </div>
 
                     {/* View button */}
-                    <button className="w-full mt-4 py-2 bg-gray-700 hover:bg-yellow-400 text-white hover:text-gray-900 rounded-lg text-sm font-medium transition-colors">
+                    <button className="w-full mt-4 py-2 bg-gray-700 hover:bg-brand-yellow text-white hover:text-gray-900 rounded-lg text-sm font-medium transition-colors">
                       View Map Details
                     </button>
                   </div>
@@ -390,7 +390,7 @@ const MapsIndex = () => {
           </div>
         ) : (
           <div className="flex flex-col items-center justify-center h-64 bg-gray-800/50 rounded-xl border border-gray-700">
-            <div className="text-yellow-400 text-6xl mb-4">
+            <div className="text-brand-yellow text-6xl mb-4">
               <MapPin />
             </div>
             <h3 className="text-white text-xl font-bold mb-2">No maps found</h3>
@@ -398,7 +398,7 @@ const MapsIndex = () => {
             {searchQuery && (
               <button
                 onClick={() => setSearchQuery("")}
-                className="mt-4 px-4 py-2 bg-yellow-400 text-gray-900 font-bold rounded-lg"
+                className="mt-4 px-4 py-2 bg-brand-yellow text-gray-900 font-bold rounded-lg"
               >
                 Clear Search
               </button>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -330,7 +330,7 @@ export default function Home() {
         
         {/* Tag Bar */}
         <div className="bg-gray-950 border-b border-gray-800">
-          <div className="max-w-full mx-auto px-3 sm:px-5 py-4">
+          <div className="container mx-auto px-4 md:px-6 py-4">
             <div className="flex gap-3 overflow-x-auto scrollbar-hide">
               {dynamicTags.map((tag) => (
                 <button
@@ -338,7 +338,7 @@ export default function Home() {
                   className={`
                     px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap flex-shrink-0 transition-all duration-200
                     ${activeTag === tag 
-                      ? 'bg-yellow-400 text-gray-900 hover:bg-yellow-300' 
+                      ? 'bg-brand-yellow text-gray-900 hover:bg-brand-yellow'
                       : 'bg-gray-800 text-gray-300 border border-gray-700 hover:bg-gray-700 hover:border-gray-600'
                     }
                   `}
@@ -352,7 +352,7 @@ export default function Home() {
         </div>
         
         {/* Main Content */}
-        <div className="max-w-full mx-auto px-3 sm:px-5 py-6 sm:py-8">
+        <div className="container mx-auto px-4 md:px-6 py-6 sm:py-8">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-8 lg:gap-x-5 lg:gap-y-10">
             {displayedVideos.map((video) => (
               <VideoCard 

--- a/src/app/players/[playerName]/page.js
+++ b/src/app/players/[playerName]/page.js
@@ -468,7 +468,7 @@ const PlayerPage = ({ params }) => {
     return (
       <div className="min-h-screen bg-gradient-to-br from-gray-700 via-gray-800 to-gray-900 flex items-center justify-center">
         <div className="text-center">
-          <div className="w-16 h-16 border-4 border-gray-600 border-t-yellow-400 rounded-full animate-spin mx-auto mb-4"></div>
+          <div className="w-16 h-16 border-4 border-gray-600 border-t-brand-yellow rounded-full animate-spin mx-auto mb-4"></div>
           <p className="text-white text-lg font-medium">
             Loading player data...
           </p>
@@ -547,9 +547,9 @@ const PlayerPage = ({ params }) => {
           </div>
 
           {/* Content */}
-          <div className="relative z-30 container mx-auto h-full flex items-center justify-center px-6">
+          <div className="relative z-30 container mx-auto h-full flex items-center justify-center px-4 md:px-6">
             <div className="text-center max-w-xl space-y-4">
-              <div className="relative w-32 h-32 mx-auto overflow-hidden rounded-full border-4 border-yellow-400/50 shadow-lg">
+              <div className="relative w-32 h-32 mx-auto overflow-hidden rounded-full border-4 border-brand-yellow/50 shadow-lg">
                 {player.image_url ? (
                   <img
                     src={player.image_url}
@@ -557,7 +557,7 @@ const PlayerPage = ({ params }) => {
                     className="w-full h-full object-cover"
                   />
                 ) : (
-                  <div className="w-full h-full bg-gray-800 flex items-center justify-center text-yellow-400 text-5xl font-bold">
+                  <div className="w-full h-full bg-gray-800 flex items-center justify-center text-brand-yellow text-5xl font-bold">
                     {playerName.charAt(0).toUpperCase()}
                   </div>
                 )}
@@ -569,7 +569,7 @@ const PlayerPage = ({ params }) => {
               <p className="text-gray-300 text-lg">{player.real_name}</p>
 
               {player.current_team?.name && (
-                <div className="inline-flex items-center bg-gray-800/60 px-3 py-1 rounded-full text-yellow-400 text-sm font-medium">
+                <div className="inline-flex items-center bg-gray-800/60 px-3 py-1 rounded-full text-brand-yellow text-sm font-medium">
                   <Shield className="w-4 h-4 mr-2" />
                   {player.current_team.name}
                 </div>
@@ -581,7 +581,7 @@ const PlayerPage = ({ params }) => {
                     href={`https://twitter.com/${player.twitter}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="hover:text-yellow-400"
+                    className="hover:text-brand-yellow"
                   >
                     <Twitter className="w-6 h-6" />
                   </a>
@@ -669,7 +669,7 @@ const PlayerPage = ({ params }) => {
               <div>
                 <div className="text-gray-400 text-xs">Favorite Map</div>
                 <div className="flex items-center text-white">
-                  <MapPin className="w-5 h-5 mr-1 text-yellow-400" />
+                  <MapPin className="w-5 h-5 mr-1 text-brand-yellow" />
                   {player.favorite_map}
                 </div>
               </div>
@@ -678,7 +678,7 @@ const PlayerPage = ({ params }) => {
                   <div className="text-gray-400 text-xs">Liquipedia</div>
                   <button
                     onClick={() => setTeamHistoryOpen(!teamHistoryOpen)}
-                    className="flex items-center text-gray-400 text-xs space-x-1 hover:text-yellow-400"
+                    className="flex items-center text-gray-400 text-xs space-x-1 hover:text-brand-yellow"
                   >
                     <span>Team History</span>
                     {teamHistoryOpen ? (
@@ -701,7 +701,7 @@ const PlayerPage = ({ params }) => {
                             {entry.start_date} &ndash; {entry.end_date}
                           </div>
                         </div>
-                        <Shield className="w-5 h-5 text-yellow-400" />
+                        <Shield className="w-5 h-5 text-brand-yellow" />
                       </li>
                     ))}
                   </ul>
@@ -714,7 +714,7 @@ const PlayerPage = ({ params }) => {
         {/* Utility Book Section */}
         <div className="max-w-4xl mx-auto mt-6 sm:mt-10 bg-gray-900/80 backdrop-blur-lg rounded-xl p-4 sm:p-6">
           <div className="flex items-center mb-4">
-            <BookOpen className="w-6 h-6 text-yellow-400 mr-2" />
+            <BookOpen className="w-6 h-6 text-brand-yellow mr-2" />
             <h2 className="text-xl font-bold text-white">
               {playerName}&apos;s Utility Book
             </h2>
@@ -747,7 +747,7 @@ const PlayerPage = ({ params }) => {
                 className="bg-gray-800/60 p-4 rounded-lg flex flex-col"
               >
                 <div className="flex items-center mb-2">
-                  <MapPin className="w-5 h-5 text-yellow-400 mr-2" />
+                  <MapPin className="w-5 h-5 text-brand-yellow mr-2" />
                   <span className="text-white font-semibold">{util.map}</span>
                 </div>
                 <div className="text-white font-bold">{util.title}</div>
@@ -771,9 +771,9 @@ const PlayerPage = ({ params }) => {
                     setActiveVideoId(util.videoId);
                     setIsFullScreenPlayer(true);
                   }}
-                  className="mt-auto self-start flex items-center gap-2 px-4 py-2 rounded-md border border-gray-600 text-white hover:border-yellow-400 transition"
+                  className="mt-auto self-start flex items-center gap-2 px-4 py-2 rounded-md border border-gray-600 text-white hover:border-brand-yellow transition"
                 >
-                  <Play className="w-4 h-4 text-yellow-400" />
+                  <Play className="w-4 h-4 text-brand-yellow" />
                   <span className="text-sm">View Utility</span>
                 </button>
               </div>
@@ -788,12 +788,12 @@ const PlayerPage = ({ params }) => {
       </div>
 
       {/* Main Content */}
-      <main className="container mx-auto px-4 sm:px-6 py-8 sm:py-12 bg-pattern relative z-10">
+      <main className="container mx-auto px-4 md:px-6 py-8 sm:py-12 bg-pattern relative z-10">
         {/* == Best Game of All Time == */}
         {player?.best_game && (
           <section className="mb-16">
             <div className="flex items-center mb-4">
-              <Star className="w-6 h-6 text-yellow-400 mr-2" />
+              <Star className="w-6 h-6 text-brand-yellow mr-2" />
               <h2 className="text-2xl font-bold text-white">
                 {playerName}&apos;s Best Game of All Time
               </h2>

--- a/src/app/players/page.jsx
+++ b/src/app/players/page.jsx
@@ -157,7 +157,7 @@ const PlayersIndex = () => {
     return (
       <div className="min-h-screen bg-gradient-to-br from-gray-700 via-gray-800 to-gray-900 flex items-center justify-center">
         <div className="text-center">
-          <div className="w-16 h-16 border-4 border-gray-600 border-t-yellow-400 rounded-full animate-spin mx-auto mb-4"></div>
+          <div className="w-16 h-16 border-4 border-gray-600 border-t-brand-yellow rounded-full animate-spin mx-auto mb-4"></div>
           <p className="text-white text-lg font-medium">Loading players...</p>
         </div>
       </div>
@@ -176,7 +176,7 @@ const PlayersIndex = () => {
       {/* Hero Header */}
       <div className="relative py-16 bg-gradient-to-b from-gray-800 to-gray-900">
         <div className="absolute inset-0 bg-yellow-400/5 mix-blend-overlay"></div>
-        <div className="container mx-auto px-6 text-center">
+        <div className="container mx-auto px-4 md:px-6 text-center">
           <div className="mt-20"></div>
           <HeroHeading>CS2 Pro Players</HeroHeading>
           <p className="text-gray-300 max-w-2xl mx-auto mb-8">
@@ -192,14 +192,14 @@ const PlayersIndex = () => {
                 placeholder="Search players by name or team..."
                 value={searchQuery}
                 onChange={handleSearchChange}
-                className="w-full p-4 pl-12 bg-gray-800 border border-gray-700 rounded-xl text-white focus:outline-none focus:border-yellow-400"
+                className="w-full p-4 pl-12 bg-gray-800 border border-gray-700 rounded-xl text-white focus:outline-none focus:border-brand-yellow"
               />
               <Search className="absolute left-4 top-4 h-5 w-5 text-gray-400" />
 
               <button
                 type="button"
                 onClick={() => setIsFilterModalOpen(true)}
-                className="absolute right-3 top-3 p-1 bg-gray-700 hover:bg-yellow-400 hover:text-gray-900 rounded-lg transition-colors"
+                className="absolute right-3 top-3 p-1 bg-gray-700 hover:bg-brand-yellow hover:text-gray-900 rounded-lg transition-colors"
               >
                 <Filter className="h-5 w-5" />
               </button>
@@ -209,18 +209,18 @@ const PlayersIndex = () => {
       </div>
 
       {/* Main Content */}
-      <main className="container mx-auto px-6 py-12">
+      <main className="container mx-auto px-4 md:px-6 py-12">
         {/* Filter tags */}
         {filtersApplied.team && (
           <div className="mb-8 flex items-center">
             <span className="text-gray-400 mr-2">Filtered by:</span>
-            <div className="bg-gray-800 px-3 py-1 rounded-full text-yellow-400 text-sm font-medium flex items-center">
+            <div className="bg-gray-800 px-3 py-1 rounded-full text-brand-yellow text-sm font-medium flex items-center">
               Team: {filtersApplied.team}
               <button
                 onClick={() =>
                   setFiltersApplied((prev) => ({ ...prev, team: "" }))
                 }
-                className="ml-2 text-gray-400 hover:text-yellow-400"
+                className="ml-2 text-gray-400 hover:text-brand-yellow"
               >
                 &times;
               </button>
@@ -262,7 +262,7 @@ const PlayersIndex = () => {
           </div>
         ) : (
           <div className="flex flex-col items-center justify-center h-64 bg-gray-800/50 rounded-xl border border-gray-700">
-            <div className="text-yellow-400 text-6xl mb-4">
+            <div className="text-brand-yellow text-6xl mb-4">
               <Users />
             </div>
             <h3 className="text-white text-xl font-bold mb-2">
@@ -272,7 +272,7 @@ const PlayersIndex = () => {
             {(searchQuery || filtersApplied.team) && (
               <button
                 onClick={handleResetFilters}
-                className="mt-4 px-4 py-2 bg-yellow-400 text-gray-900 font-bold rounded-lg"
+                className="mt-4 px-4 py-2 bg-brand-yellow text-gray-900 font-bold rounded-lg"
               >
                 Reset Filters
               </button>
@@ -282,7 +282,7 @@ const PlayersIndex = () => {
 
         {isLoading && (
           <div className="flex justify-center mt-8">
-            <div className="w-10 h-10 border-4 border-gray-600 border-t-yellow-400 rounded-full animate-spin"></div>
+            <div className="w-10 h-10 border-4 border-gray-600 border-t-brand-yellow rounded-full animate-spin"></div>
           </div>
         )}
 

--- a/src/app/search/page.jsx
+++ b/src/app/search/page.jsx
@@ -404,7 +404,7 @@ function SearchResultsContent() {
     <div className="min-h-screen bg-gray-950">
       <div className="h-16"></div>
       
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
+      <div className="container mx-auto px-4 md:px-6 py-6 sm:py-8">
         <h1 className="text-lg sm:text-xl text-white font-medium mb-1">
           Search results for <span className="font-normal">"{searchQuery}"</span>
         </h1>
@@ -412,7 +412,7 @@ function SearchResultsContent() {
       </div>
 
       <div className="sticky top-0 bg-gray-950/95 backdrop-blur-md border-b border-gray-800 z-20">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4">
+        <div className="container mx-auto px-4 md:px-6 py-3 sm:py-4">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-4">
             <div className="flex gap-2 sm:gap-3 overflow-x-auto scrollbar-hide w-full sm:w-auto pb-1">
               {PILL_OPTIONS.map(pill => (
@@ -453,7 +453,7 @@ function SearchResultsContent() {
         )}
       </div>
 
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
+      <div className="container mx-auto px-4 md:px-6 py-6 sm:py-8">
         <div className="space-y-6 sm:space-y-8">
           {displayedItems.map((item) => (
             <div key={item.id}>
@@ -566,7 +566,7 @@ function PlayerCard({ player }) {
               <span>ELO {player.faceit_elo}</span>
             </div>
             {player.fpl_rank && (
-              <div className="flex items-center gap-1 text-yellow-400">
+              <div className="flex items-center gap-1 text-brand-yellow">
                 <Users size={12} />
                 <span>{player.fpl_rank}</span>
               </div>

--- a/src/components/layout/GlobalLayout.jsx
+++ b/src/components/layout/GlobalLayout.jsx
@@ -14,6 +14,7 @@ function GlobalLayoutContent({ children }) {
     setSearchActive,
     isMenuOpen,
     setIsMenuOpen,
+    isSidebarCollapsed,
     demoType,
     handleSwitchDemoType,
   } = useNavbar();
@@ -37,7 +38,17 @@ function GlobalLayoutContent({ children }) {
 
       <div className="flex">
         {shouldShowNavigation && <Sidebar />}
-        <main className={`flex-1 ${shouldShowNavigation ? "md:ml-64" : ""}`}>{children}</main>
+        <main
+          className={`flex-1 ${
+            shouldShowNavigation
+              ? isSidebarCollapsed
+                ? "md:ml-16"
+                : "md:ml-64"
+              : ""
+          }`}
+        >
+          {children}
+        </main>
       </div>
 
       {shouldShowNavigation && <Footer />}

--- a/src/components/layout/GlobalLayout.jsx
+++ b/src/components/layout/GlobalLayout.jsx
@@ -15,6 +15,7 @@ function GlobalLayoutContent({ children }) {
     isMenuOpen,
     setIsMenuOpen,
     isSidebarCollapsed,
+    setIsSidebarCollapsed,
     demoType,
     handleSwitchDemoType,
   } = useNavbar();
@@ -33,6 +34,8 @@ function GlobalLayoutContent({ children }) {
           setSearchActive={setSearchActive}
           setIsMenuOpen={setIsMenuOpen}
           isMenuOpen={isMenuOpen}
+          isSidebarCollapsed={isSidebarCollapsed}
+          setIsSidebarCollapsed={setIsSidebarCollapsed}
         />
       )}
 

--- a/src/components/layout/GlobalLayout.jsx
+++ b/src/components/layout/GlobalLayout.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import { usePathname } from "next/navigation";
 import Navbar from "../navigation/Navbar";
 import Footer from "../navigation/Footer";
+import Sidebar from "../navigation/Sidebar";
 import { NavbarProvider, useNavbar } from "../../context/NavbarContext";
 
 function GlobalLayoutContent({ children }) {
@@ -34,7 +35,10 @@ function GlobalLayoutContent({ children }) {
         />
       )}
 
-      <main>{children}</main>
+      <div className="flex">
+        {shouldShowNavigation && <Sidebar />}
+        <main className={`flex-1 ${shouldShowNavigation ? "md:ml-64" : ""}`}>{children}</main>
+      </div>
 
       {shouldShowNavigation && <Footer />}
     </>

--- a/src/components/navigation/Footer.jsx
+++ b/src/components/navigation/Footer.jsx
@@ -3,8 +3,8 @@ import LogoHeading from "../brand/LogoHeading";
 import { Caption } from "../typography";
 
 const Footer = () => (
-  <footer className="bg-gray-800 py-10 border-t border-gray-700">
-    <div className="container mx-auto px-6">
+  <footer className="bg-gray-800 border-t border-gray-700 py-8">
+    <div className="container mx-auto px-4 md:px-6">
       <div className="flex flex-col md:flex-row justify-between items-center mb-10">
         <div className="mb-8 md:mb-0">
           <LogoHeading size={1.5} />
@@ -18,7 +18,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Home
                 </a>
@@ -26,7 +26,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Maps
                 </a>
@@ -34,7 +34,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Players
                 </a>
@@ -42,7 +42,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Events
                 </a>
@@ -56,7 +56,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   About
                 </a>
@@ -64,7 +64,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Contact
                 </a>
@@ -72,7 +72,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   FAQ
                 </a>
@@ -80,7 +80,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                  className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Support
                 </a>
@@ -94,7 +94,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                    className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Privacy Policy
                 </a>
@@ -102,7 +102,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                    className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Terms of Service
                 </a>
@@ -110,7 +110,7 @@ const Footer = () => (
               <li>
                 <a
                   href="#"
-                  className="text-gray-400 hover:text-yellow-400 transition-colors"
+                    className="text-gray-400 hover:text-brand-yellow transition-colors"
                 >
                   Cookie Policy
                 </a>
@@ -127,7 +127,7 @@ const Footer = () => (
         <div className="flex space-x-4">
           <a
             href="#"
-            className="text-gray-400 hover:text-yellow-400 transition-colors"
+            className="text-gray-400 hover:text-brand-yellow transition-colors"
           >
             <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center hover:bg-gray-600">
               <img
@@ -139,7 +139,7 @@ const Footer = () => (
           </a>
           <a
             href="#"
-            className="text-gray-400 hover:text-yellow-400 transition-colors"
+            className="text-gray-400 hover:text-brand-yellow transition-colors"
           >
             <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center hover:bg-gray-600">
               <img
@@ -151,7 +151,7 @@ const Footer = () => (
           </a>
           <a
             href="#"
-            className="text-gray-400 hover:text-yellow-400 transition-colors"
+            className="text-gray-400 hover:text-brand-yellow transition-colors"
           >
             <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center hover:bg-gray-600">
               <img

--- a/src/components/navigation/Navbar.jsx
+++ b/src/components/navigation/Navbar.jsx
@@ -73,7 +73,7 @@ export default function Navbar({
   return (
     <header className={`fixed top-0 w-full z-50 ${glassBg}`}>
       <div className="w-full px-4 md:px-6">
-        <div className="flex items-center justify-between py-4">
+        <div className="flex items-center justify-between py-4 gap-4">
           <div className="flex items-center space-x-2">
             <button
               onClick={() => setIsSidebarCollapsed((c) => !c)}
@@ -91,24 +91,24 @@ export default function Navbar({
             </Link>
           </div>
 
-          {/* Desktop Nav */}
-          <nav className="hidden md:flex flex-grow items-center justify-end space-x-6">
-            {/* Search Bar */}
-            <div className="flex-grow max-w-xl">
-              <form onSubmit={handleSearchSubmit} className="relative w-full">
-                <input
-                  type="text"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder="Search demos, players, teams, utilities..."
-                  className="w-full py-2 pl-4 pr-10 rounded-full border border-gray-600 bg-transparent text-gray-100 placeholder-gray-400 focus:outline-none"
-                />
-                <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2">
-                  <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
-                </button>
-              </form>
-            </div>
+          {/* Desktop search */}
+          <div className="hidden md:flex flex-1 justify-center">
+            <form onSubmit={handleSearchSubmit} className="relative w-full max-w-xl">
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search demos, players, teams, utilities..."
+                className="w-full py-2 pl-4 pr-10 rounded-full border border-gray-600 bg-transparent text-gray-100 placeholder-gray-400 focus:outline-none"
+              />
+              <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2">
+                <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
+              </button>
+            </form>
+          </div>
 
+          {/* Desktop nav icons */}
+          <nav className="hidden md:flex items-center space-x-6">
             {/* Notifications */}
             {isLoggedIn && (
               <Link href="/user">

--- a/src/components/navigation/Navbar.jsx
+++ b/src/components/navigation/Navbar.jsx
@@ -92,18 +92,18 @@ export default function Navbar({
           </div>
 
           {/* Desktop Nav */}
-          <nav className="hidden md:flex flex-grow items-center justify-center space-x-6">
+          <nav className="hidden md:flex flex-grow items-center justify-end space-x-6">
             {/* Search Bar */}
             <div className="flex-grow max-w-xl">
-              <form onSubmit={handleSearchSubmit} className="flex items-center w-full">
+              <form onSubmit={handleSearchSubmit} className="relative w-full">
                 <input
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search demos, players, teams, utilities..."
-                  className="px-4 py-2 rounded-full bg-gray-800 text-gray-100 placeholder-gray-400 focus:outline-none w-full"
+                  className="w-full py-2 pl-4 pr-10 rounded-full border border-gray-600 bg-transparent text-gray-100 placeholder-gray-400 focus:outline-none"
                 />
-                <button type="submit" className="ml-2">
+                <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2">
                   <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
                 </button>
               </form>
@@ -181,16 +181,16 @@ export default function Navbar({
         <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
           <form
             onSubmit={handleSearchSubmit}
-            className="w-full max-w-md flex items-center bg-gray-800 rounded-full px-4"
+            className="w-full max-w-md relative"
           >
             <input
               type="text"
               value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search demos, players, teams, utilities..."
-              className="flex-grow py-2 bg-transparent placeholder-gray-400 text-white focus:outline-none"
+              className="w-full py-2 pl-4 pr-10 rounded-full border border-gray-600 bg-transparent placeholder-gray-400 text-white focus:outline-none"
             />
-            <button type="submit">
+            <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2">
               <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
             </button>
           </form>
@@ -202,15 +202,15 @@ export default function Navbar({
         <div className="fixed inset-0 z-40 bg-black/90 backdrop-blur-lg overflow-y-auto">
           <div className="container mx-auto px-4 md:px-6 py-6">
             <nav className="flex flex-col space-y-6">
-              <form onSubmit={handleSearchSubmit} className="flex items-center">
+              <form onSubmit={handleSearchSubmit} className="relative">
                 <input
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search demos, players, teams, utilities..."
-                  className="px-4 py-2 rounded-full bg-gray-700 text-gray-100 placeholder-gray-400 w-full focus:outline-none"
+                  className="w-full py-2 pl-4 pr-10 rounded-full border border-gray-600 bg-transparent text-gray-100 placeholder-gray-400 focus:outline-none"
                 />
-                <button type="submit" className="ml-2">
+                <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2">
                   <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
                 </button>
               </form>

--- a/src/components/navigation/Navbar.jsx
+++ b/src/components/navigation/Navbar.jsx
@@ -3,7 +3,15 @@
 import React, { useState, useEffect, useContext } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { Search, Menu, X, BellRing, LogIn } from "lucide-react";
+import {
+  Search,
+  Menu,
+  X,
+  BellRing,
+  LogIn,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from "lucide-react";
 import { UserContext } from "../../../context/UserContext";
 import LogoHeading from "../brand/LogoHeading";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
@@ -15,6 +23,8 @@ export default function Navbar({
   setSearchActive = () => {},
   setIsMenuOpen = () => {},
   isMenuOpen = false,
+  isSidebarCollapsed = false,
+  setIsSidebarCollapsed = () => {},
 }) {
   const [isScrolled, setIsScrolled] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
@@ -62,12 +72,24 @@ export default function Navbar({
 
   return (
     <header className={`fixed top-0 w-full z-50 ${glassBg}`}>
-      <div className="container mx-auto px-4 md:px-8">
+      <div className="w-full px-2 md:px-4">
         <div className="flex items-center justify-between py-3">
-          {/* Logo */}
-          <Link href="/" className="flex items-center">
-            <LogoHeading size={1.5} />
-          </Link>
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={() => setIsSidebarCollapsed((c) => !c)}
+              className="hidden md:flex p-2 text-gray-100 hover:text-yellow-400"
+            >
+              {isSidebarCollapsed ? (
+                <PanelLeftOpen className="h-5 w-5" />
+              ) : (
+                <PanelLeftClose className="h-5 w-5" />
+              )}
+            </button>
+            {/* Logo */}
+            <Link href="/" className="flex items-center">
+              <LogoHeading size={1.5} />
+            </Link>
+          </div>
 
           {/* Desktop Nav */}
           <nav className="hidden md:flex flex-grow items-center justify-center space-x-6">

--- a/src/components/navigation/Navbar.jsx
+++ b/src/components/navigation/Navbar.jsx
@@ -72,12 +72,12 @@ export default function Navbar({
 
   return (
     <header className={`fixed top-0 w-full z-50 ${glassBg}`}>
-      <div className="w-full px-2 md:px-4">
-        <div className="flex items-center justify-between py-3">
+      <div className="w-full px-4 md:px-6">
+        <div className="flex items-center justify-between py-4">
           <div className="flex items-center space-x-2">
             <button
               onClick={() => setIsSidebarCollapsed((c) => !c)}
-              className="hidden md:flex p-2 text-gray-100 hover:text-yellow-400"
+              className="hidden md:flex p-2 text-gray-100 hover:text-brand-yellow"
             >
               {isSidebarCollapsed ? (
                 <PanelLeftOpen className="h-5 w-5" />
@@ -104,7 +104,7 @@ export default function Navbar({
                   className="px-4 py-2 rounded-full bg-gray-800 text-gray-100 placeholder-gray-400 focus:outline-none w-full"
                 />
                 <button type="submit" className="ml-2">
-                  <Search className="h-5 w-5 text-gray-100 hover:text-yellow-400" />
+                  <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
                 </button>
               </form>
             </div>
@@ -112,7 +112,7 @@ export default function Navbar({
             {/* Notifications */}
             {isLoggedIn && (
               <Link href="/user">
-                <button className="p-2 relative text-gray-300 hover:text-yellow-400">
+                <button className="p-2 relative text-gray-300 hover:text-brand-yellow">
                   <BellRing className="h-5 w-5" />
                   <span className="absolute top-0 right-0 h-2 w-2 bg-yellow-400 rounded-full" />
                 </button>
@@ -191,7 +191,7 @@ export default function Navbar({
               className="flex-grow py-2 bg-transparent placeholder-gray-400 text-white focus:outline-none"
             />
             <button type="submit">
-              <Search className="h-5 w-5 text-gray-100 hover:text-yellow-400" />
+              <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
             </button>
           </form>
         </div>
@@ -200,7 +200,7 @@ export default function Navbar({
       {/* Mobile Menu Overlay */}
       {isMenuOpen && (
         <div className="fixed inset-0 z-40 bg-black/90 backdrop-blur-lg overflow-y-auto">
-          <div className="container mx-auto px-4 py-6">
+          <div className="container mx-auto px-4 md:px-6 py-6">
             <nav className="flex flex-col space-y-6">
               <form onSubmit={handleSearchSubmit} className="flex items-center">
                 <input
@@ -211,14 +211,14 @@ export default function Navbar({
                   className="px-4 py-2 rounded-full bg-gray-700 text-gray-100 placeholder-gray-400 w-full focus:outline-none"
                 />
                 <button type="submit" className="ml-2">
-                  <Search className="h-5 w-5 text-gray-100 hover:text-yellow-400" />
+                  <Search className="h-5 w-5 text-gray-100 hover:text-brand-yellow" />
                 </button>
               </form>
 
               {user ? (
                 <button
                   onClick={handleSignOut}
-                  className="text-left text-gray-200 hover:text-yellow-400"
+                  className="text-left text-gray-200 hover:text-brand-yellow"
                 >
                   Sign Out
                 </button>

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -111,8 +111,8 @@ export default function Sidebar({ items }) {
         }`}
       >
         {!isSidebarCollapsed && (
-          <div className="bg-brand-yellow text-gray-900 rounded p-3 text-center font-bold text-sm mb-4">
-            Upgrade to Pro for $6.99/mo
+          <div className="border border-brand-yellow text-brand-yellow rounded p-3 text-center text-xs mb-4">
+            Upgrade to Pro for <span className="font-bold">$6.99/mo</span>
           </div>
         )}
         <nav
@@ -134,7 +134,8 @@ export default function Sidebar({ items }) {
           ))}
           {!isSidebarCollapsed && (
             <>
-              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">You</h3>
+              <hr className="border-gray-700 my-4" />
+              <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">You</h3>
               {youItems.map((item) => (
                 <Link
                   key={item.label}
@@ -145,8 +146,8 @@ export default function Sidebar({ items }) {
                   <span>{item.label}</span>
                 </Link>
               ))}
-
-              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">Analytics</h3>
+              <hr className="border-gray-700 my-4" />
+              <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">Analytics</h3>
               {analyticsItems.map((item) => (
                 <Link
                   key={item.label}
@@ -198,15 +199,15 @@ export default function Sidebar({ items }) {
       {/* Mobile overlay */}
         {isMenuOpen && (
         <div className="fixed inset-0 z-40 flex md:hidden">
-          <div className="w-64 bg-gray-900/90 backdrop-blur p-6 space-y-4">
+          <div className="w-64 bg-gray-900/90 backdrop-blur p-6 space-y-4 overflow-y-auto sidebar-scrollbar">
             <button
               onClick={() => setIsMenuOpen(false)}
               className="p-2 text-gray-100 hover:text-brand-yellow"
             >
               <X className="h-6 w-6" />
             </button>
-            <div className="bg-brand-yellow text-gray-900 rounded p-3 text-center font-bold text-sm">
-              Upgrade to Pro for $6.99/mo
+            <div className="border border-brand-yellow text-brand-yellow rounded p-3 text-center text-xs">
+              Upgrade to Pro for <span className="font-bold">$6.99/mo</span>
             </div>
             <nav className="flex flex-col space-y-4">
               {menuItems.map((item, index) => (
@@ -220,7 +221,8 @@ export default function Sidebar({ items }) {
                   <span>{item.label}</span>
                 </Link>
               ))}
-              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">You</h3>
+              <hr className="border-gray-700 my-4" />
+              <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">You</h3>
               {youItems.map((item) => (
                 <Link
                   key={item.label}
@@ -232,8 +234,8 @@ export default function Sidebar({ items }) {
                   <span>{item.label}</span>
                 </Link>
               ))}
-
-              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">Analytics</h3>
+              <hr className="border-gray-700 my-4" />
+              <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">Analytics</h3>
               {analyticsItems.map((item) => (
                 <Link
                   key={item.label}

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { X } from "lucide-react";
+import { useNavbar } from "../../context/NavbarContext";
+
+export default function Sidebar({ items }) {
+  const { isMenuOpen, setIsMenuOpen } = useNavbar();
+
+  const menuItems =
+    items || [
+      { label: "Home", href: "/" },
+      { label: "Demos", href: "/demos" },
+      { label: "Players", href: "/players" },
+      { label: "Maps", href: "/maps" },
+      { label: "Utility Book", href: "/utility-book" },
+    ];
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <aside className="hidden md:flex fixed top-16 left-0 bottom-0 w-64 flex-col bg-gray-900 border-r border-gray-700 p-6 space-y-4">
+        <nav className="flex flex-col space-y-4">
+          {menuItems.map((item, index) => (
+            <Link key={index} href={item.href} className="text-gray-200 hover:text-yellow-400">
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Mobile overlay */}
+      {isMenuOpen && (
+        <div className="fixed inset-0 z-40 flex md:hidden">
+          <div className="w-64 bg-gray-900/90 backdrop-blur p-6 space-y-4">
+            <button
+              onClick={() => setIsMenuOpen(false)}
+              className="p-2 text-gray-100 hover:text-yellow-400"
+            >
+              <X className="h-6 w-6" />
+            </button>
+            <nav className="flex flex-col space-y-4">
+              {menuItems.map((item, index) => (
+                <Link
+                  key={index}
+                  href={item.href}
+                  onClick={() => setIsMenuOpen(false)}
+                  className="text-gray-200 hover:text-yellow-400"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <div className="flex-1" onClick={() => setIsMenuOpen(false)} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -9,6 +9,13 @@ import {
   Users,
   Map,
   BookOpen,
+  Clock,
+  Scissors,
+  Crosshair,
+  MonitorPlay,
+  BrainCircuit,
+  Activity,
+  Trophy,
 } from "lucide-react";
 import { useNavbar } from "../../context/NavbarContext";
 
@@ -33,6 +40,53 @@ export default function Sidebar({ items }) {
       },
     ];
 
+  const youItems = [
+    { label: "History", href: "/history", icon: <Clock className="h-5 w-5" /> },
+    {
+      label: "Your Matches",
+      href: "/matches",
+      icon: <Crosshair className="h-5 w-5" />,
+    },
+    {
+      label: "Your Demos",
+      href: "/your-demos",
+      icon: <Film className="h-5 w-5" />,
+    },
+    {
+      label: "Watch Later",
+      href: "/watch-later",
+      icon: <Clock className="h-5 w-5" />,
+    },
+    {
+      label: "Your Clips",
+      href: "/clips",
+      icon: <Scissors className="h-5 w-5" />,
+    },
+  ];
+
+  const analyticsItems = [
+    {
+      label: "2D Viewer",
+      href: "/analytics/2d-viewer",
+      icon: <MonitorPlay className="h-5 w-5" />,
+    },
+    {
+      label: "Deep Demo Viewer",
+      href: "/analytics/deep-demo-viewer",
+      icon: <BrainCircuit className="h-5 w-5" />,
+    },
+    {
+      label: "Your Development",
+      href: "/analytics/development",
+      icon: <Activity className="h-5 w-5" />,
+    },
+    {
+      label: "Compare to Pro",
+      href: "/analytics/compare-pro",
+      icon: <Trophy className="h-5 w-5" />,
+    },
+  ];
+
   const footerSections = [
     {
       title: "Navigation",
@@ -52,13 +106,18 @@ export default function Sidebar({ items }) {
     <>
       {/* Desktop sidebar */}
       <aside
-        className={`hidden md:flex fixed top-16 left-0 bottom-0 z-40 flex-col border-r border-gray-700 bg-black/50 backdrop-blur-lg transition-all duration-300 ${
+        className={`hidden md:flex fixed top-16 left-0 bottom-0 z-40 flex-col border-r border-gray-700 bg-black/50 backdrop-blur-lg transition-all duration-300 overflow-y-auto sidebar-scrollbar ${
           isSidebarCollapsed ? "w-16 p-3" : "w-64 p-6"
         }`}
       >
+        {!isSidebarCollapsed && (
+          <div className="bg-brand-yellow text-gray-900 rounded p-3 text-center font-bold text-sm mb-4">
+            Upgrade to Pro for $6.99/mo
+          </div>
+        )}
         <nav
-          className={`flex flex-col mt-4 space-y-4 ${
-            isSidebarCollapsed ? "items-center" : ""
+          className={`flex flex-col space-y-4 ${
+            isSidebarCollapsed ? "items-center" : "mt-4"
           }`}
         >
           {menuItems.map((item, index) => (
@@ -73,6 +132,33 @@ export default function Sidebar({ items }) {
               {!isSidebarCollapsed && <span>{item.label}</span>}
             </Link>
           ))}
+          {!isSidebarCollapsed && (
+            <>
+              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">You</h3>
+              {youItems.map((item) => (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className="flex items-center space-x-3 text-sm text-gray-200 hover:text-brand-yellow"
+                >
+                  {item.icon}
+                  <span>{item.label}</span>
+                </Link>
+              ))}
+
+              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">Analytics</h3>
+              {analyticsItems.map((item) => (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className="flex items-center space-x-3 text-sm text-gray-200 hover:text-brand-yellow"
+                >
+                  {item.icon}
+                  <span>{item.label}</span>
+                </Link>
+              ))}
+            </>
+          )}
         </nav>
         {!isSidebarCollapsed && (
           <div className="mt-auto space-y-6 pt-6 border-t border-gray-700 overflow-y-auto">
@@ -110,7 +196,7 @@ export default function Sidebar({ items }) {
       </aside>
 
       {/* Mobile overlay */}
-      {isMenuOpen && (
+        {isMenuOpen && (
         <div className="fixed inset-0 z-40 flex md:hidden">
           <div className="w-64 bg-gray-900/90 backdrop-blur p-6 space-y-4">
             <button
@@ -119,10 +205,38 @@ export default function Sidebar({ items }) {
             >
               <X className="h-6 w-6" />
             </button>
+            <div className="bg-brand-yellow text-gray-900 rounded p-3 text-center font-bold text-sm">
+              Upgrade to Pro for $6.99/mo
+            </div>
             <nav className="flex flex-col space-y-4">
               {menuItems.map((item, index) => (
                 <Link
                   key={index}
+                  href={item.href}
+                  onClick={() => setIsMenuOpen(false)}
+                  className="flex items-center space-x-3 text-sm font-medium text-gray-200 hover:text-brand-yellow"
+                >
+                  {item.icon}
+                  <span>{item.label}</span>
+                </Link>
+              ))}
+              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">You</h3>
+              {youItems.map((item) => (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  onClick={() => setIsMenuOpen(false)}
+                  className="flex items-center space-x-3 text-sm font-medium text-gray-200 hover:text-brand-yellow"
+                >
+                  {item.icon}
+                  <span>{item.label}</span>
+                </Link>
+              ))}
+
+              <h3 className="mt-6 mb-2 text-xs font-bold uppercase text-gray-400">Analytics</h3>
+              {analyticsItems.map((item) => (
+                <Link
+                  key={item.label}
                   href={item.href}
                   onClick={() => setIsMenuOpen(false)}
                   className="flex items-center space-x-3 text-sm font-medium text-gray-200 hover:text-brand-yellow"
@@ -136,6 +250,18 @@ export default function Sidebar({ items }) {
           <div className="flex-1" onClick={() => setIsMenuOpen(false)} />
         </div>
       )}
+      <style jsx>{`
+        .sidebar-scrollbar::-webkit-scrollbar {
+          width: 8px;
+        }
+        .sidebar-scrollbar::-webkit-scrollbar-track {
+          background: transparent;
+        }
+        .sidebar-scrollbar::-webkit-scrollbar-thumb {
+          background: #374151;
+          border-radius: 4px;
+        }
+      `}</style>
     </>
   );
 }

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -2,32 +2,123 @@
 
 import React from "react";
 import Link from "next/link";
-import { X } from "lucide-react";
+import {
+  X,
+  Home,
+  Film,
+  Users,
+  Map,
+  BookOpen,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 import { useNavbar } from "../../context/NavbarContext";
 
 export default function Sidebar({ items }) {
-  const { isMenuOpen, setIsMenuOpen } = useNavbar();
+  const {
+    isMenuOpen,
+    setIsMenuOpen,
+    isSidebarCollapsed,
+    setIsSidebarCollapsed,
+  } = useNavbar();
 
   const menuItems =
     items || [
-      { label: "Home", href: "/" },
-      { label: "Demos", href: "/demos" },
-      { label: "Players", href: "/players" },
-      { label: "Maps", href: "/maps" },
-      { label: "Utility Book", href: "/utility-book" },
+      { label: "Home", href: "/", icon: <Home className="h-5 w-5" /> },
+      { label: "Demos", href: "/demos", icon: <Film className="h-5 w-5" /> },
+      { label: "Players", href: "/players", icon: <Users className="h-5 w-5" /> },
+      { label: "Maps", href: "/maps", icon: <Map className="h-5 w-5" /> },
+      {
+        label: "Utility Book",
+        href: "/utility-book",
+        icon: <BookOpen className="h-5 w-5" />,
+      },
     ];
+
+  const footerSections = [
+    {
+      title: "Navigation",
+      items: ["Home", "Maps", "Players", "Events"],
+    },
+    {
+      title: "Resources",
+      items: ["About", "Contact", "FAQ", "Support"],
+    },
+    {
+      title: "Legal",
+      items: ["Privacy Policy", "Terms of Service", "Cookie Policy"],
+    },
+  ];
 
   return (
     <>
       {/* Desktop sidebar */}
-      <aside className="hidden md:flex fixed top-16 left-0 bottom-0 w-64 flex-col bg-gray-900 border-r border-gray-700 p-6 space-y-4">
-        <nav className="flex flex-col space-y-4">
+      <aside
+        className={`hidden md:flex fixed top-16 left-0 bottom-0 z-40 flex-col border-r border-gray-700 bg-black/50 backdrop-blur-lg transition-all duration-300 ${
+          isSidebarCollapsed ? "w-16 p-2" : "w-64 p-6"
+        }`}
+      >
+        <button
+          onClick={() => setIsSidebarCollapsed((c) => !c)}
+          className="self-end p-2 text-gray-200 hover:text-yellow-400"
+        >
+          {isSidebarCollapsed ? (
+            <ChevronRight className="h-5 w-5" />
+          ) : (
+            <ChevronLeft className="h-5 w-5" />
+          )}
+        </button>
+        <nav
+          className={`flex flex-col mt-4 space-y-4 ${
+            isSidebarCollapsed ? "items-center" : ""
+          }`}
+        >
           {menuItems.map((item, index) => (
-            <Link key={index} href={item.href} className="text-gray-200 hover:text-yellow-400">
-              {item.label}
+            <Link
+              key={index}
+              href={item.href}
+              className={`flex items-center text-gray-200 hover:text-yellow-400 transition-colors ${
+                isSidebarCollapsed ? "justify-center" : "space-x-3"
+              }`}
+            >
+              {item.icon}
+              {!isSidebarCollapsed && <span>{item.label}</span>}
             </Link>
           ))}
         </nav>
+        {!isSidebarCollapsed && (
+          <div className="mt-auto space-y-6 pt-6 border-t border-gray-700 overflow-y-auto">
+            {footerSections.map((section) => (
+              <div key={section.title}>
+                <h3 className="text-white font-bold mb-2 text-sm">
+                  {section.title}
+                </h3>
+                <ul className="space-y-1 text-xs">
+                  {section.items.map((it) => (
+                    <li key={it}>
+                      <a href="#" className="text-gray-400 hover:text-yellow-400 transition-colors">
+                        {it}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+            <div className="flex space-x-3 pt-4">
+              {[1, 2, 3].map((n) => (
+                <a key={n} href="#" className="text-gray-400 hover:text-yellow-400 transition-colors">
+                  <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center hover:bg-gray-600">
+                    <img
+                      src="https://www.rnd.de/resizer/v2/7ZPVUSAZTJCCPNBTCAANTGZZVQ.jpg?auth=872c3046d03f56a91fa0b0a7faedad3feaa83153dc60fdd489e4f43c7903000e&quality=70&width=1441&height=1081&smart=true"
+                      className="w-4 h-4 rounded-full"
+                      alt="social"
+                    />
+                  </div>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
       </aside>
 
       {/* Mobile overlay */}
@@ -46,9 +137,10 @@ export default function Sidebar({ items }) {
                   key={index}
                   href={item.href}
                   onClick={() => setIsMenuOpen(false)}
-                  className="text-gray-200 hover:text-yellow-400"
+                  className="flex items-center space-x-3 text-gray-200 hover:text-yellow-400"
                 >
-                  {item.label}
+                  {item.icon}
+                  <span>{item.label}</span>
                 </Link>
               ))}
             </nav>

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -53,7 +53,7 @@ export default function Sidebar({ items }) {
       {/* Desktop sidebar */}
       <aside
         className={`hidden md:flex fixed top-16 left-0 bottom-0 z-40 flex-col border-r border-gray-700 bg-black/50 backdrop-blur-lg transition-all duration-300 ${
-          isSidebarCollapsed ? "w-16 p-2" : "w-64 p-6"
+          isSidebarCollapsed ? "w-16 p-3" : "w-64 p-6"
         }`}
       >
         <nav
@@ -65,7 +65,7 @@ export default function Sidebar({ items }) {
             <Link
               key={index}
               href={item.href}
-              className={`flex items-center text-gray-200 hover:text-yellow-400 transition-colors ${
+              className={`flex items-center text-sm font-medium text-gray-200 hover:text-brand-yellow transition-colors ${
                 isSidebarCollapsed ? "justify-center" : "space-x-3"
               }`}
             >
@@ -84,7 +84,7 @@ export default function Sidebar({ items }) {
                 <ul className="space-y-1 text-xs">
                   {section.items.map((it) => (
                     <li key={it}>
-                      <a href="#" className="text-gray-400 hover:text-yellow-400 transition-colors">
+                      <a href="#" className="text-gray-400 hover:text-brand-yellow transition-colors">
                         {it}
                       </a>
                     </li>
@@ -94,7 +94,7 @@ export default function Sidebar({ items }) {
             ))}
             <div className="flex space-x-3 pt-4">
               {[1, 2, 3].map((n) => (
-                <a key={n} href="#" className="text-gray-400 hover:text-yellow-400 transition-colors">
+                <a key={n} href="#" className="text-gray-400 hover:text-brand-yellow transition-colors">
                   <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center hover:bg-gray-600">
                     <img
                       src="https://www.rnd.de/resizer/v2/7ZPVUSAZTJCCPNBTCAANTGZZVQ.jpg?auth=872c3046d03f56a91fa0b0a7faedad3feaa83153dc60fdd489e4f43c7903000e&quality=70&width=1441&height=1081&smart=true"
@@ -115,7 +115,7 @@ export default function Sidebar({ items }) {
           <div className="w-64 bg-gray-900/90 backdrop-blur p-6 space-y-4">
             <button
               onClick={() => setIsMenuOpen(false)}
-              className="p-2 text-gray-100 hover:text-yellow-400"
+              className="p-2 text-gray-100 hover:text-brand-yellow"
             >
               <X className="h-6 w-6" />
             </button>
@@ -125,7 +125,7 @@ export default function Sidebar({ items }) {
                   key={index}
                   href={item.href}
                   onClick={() => setIsMenuOpen(false)}
-                  className="flex items-center space-x-3 text-gray-200 hover:text-yellow-400"
+                  className="flex items-center space-x-3 text-sm font-medium text-gray-200 hover:text-brand-yellow"
                 >
                   {item.icon}
                   <span>{item.label}</span>

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -87,20 +87,6 @@ export default function Sidebar({ items }) {
     },
   ];
 
-  const footerSections = [
-    {
-      title: "Navigation",
-      items: ["Home", "Maps", "Players", "Events"],
-    },
-    {
-      title: "Resources",
-      items: ["About", "Contact", "FAQ", "Support"],
-    },
-    {
-      title: "Legal",
-      items: ["Privacy Policy", "Terms of Service", "Cookie Policy"],
-    },
-  ];
 
   return (
     <>
@@ -111,7 +97,7 @@ export default function Sidebar({ items }) {
         }`}
       >
         {!isSidebarCollapsed && (
-          <div className="border border-brand-yellow text-brand-yellow rounded p-3 text-center text-xs mb-4">
+          <div className="border border-brand-yellow text-brand-yellow rounded-lg p-3 text-center text-sm font-medium mb-4">
             Upgrade to Pro for <span className="font-bold">$6.99/mo</span>
           </div>
         )}
@@ -162,37 +148,19 @@ export default function Sidebar({ items }) {
           )}
         </nav>
         {!isSidebarCollapsed && (
-          <div className="mt-auto space-y-6 pt-6 border-t border-gray-700 overflow-y-auto">
-            {footerSections.map((section) => (
-              <div key={section.title}>
-                <h3 className="text-white font-bold mb-2 text-sm">
-                  {section.title}
-                </h3>
-                <ul className="space-y-1 text-xs">
-                  {section.items.map((it) => (
-                    <li key={it}>
-                      <a href="#" className="text-gray-400 hover:text-brand-yellow transition-colors">
-                        {it}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-            <div className="flex space-x-3 pt-4">
-              {[1, 2, 3].map((n) => (
-                <a key={n} href="#" className="text-gray-400 hover:text-brand-yellow transition-colors">
-                  <div className="w-8 h-8 bg-gray-700 rounded-full flex items-center justify-center hover:bg-gray-600">
-                    <img
-                      src="https://www.rnd.de/resizer/v2/7ZPVUSAZTJCCPNBTCAANTGZZVQ.jpg?auth=872c3046d03f56a91fa0b0a7faedad3feaa83153dc60fdd489e4f43c7903000e&quality=70&width=1441&height=1081&smart=true"
-                      className="w-4 h-4 rounded-full"
-                      alt="social"
-                    />
-                  </div>
-                </a>
-              ))}
-            </div>
-          </div>
+          <>
+            <hr className="border-gray-700 my-4" />
+            <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">Resources</h3>
+            <Link href="#" className="text-sm text-gray-200 hover:text-brand-yellow">About</Link>
+            <Link href="#" className="text-sm text-gray-200 hover:text-brand-yellow">Contact</Link>
+            <Link href="#" className="text-sm text-gray-200 hover:text-brand-yellow">FAQ</Link>
+            <Link href="#" className="text-sm text-gray-200 hover:text-brand-yellow">Support</Link>
+            <hr className="border-gray-700 my-4" />
+            <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">Legal</h3>
+            <Link href="#" className="text-sm text-gray-200 hover:text-brand-yellow">Privacy Policy</Link>
+            <Link href="#" className="text-sm text-gray-200 hover:text-brand-yellow">Terms of Service</Link>
+            <Link href="#" className="text-sm text-gray-200 hover:text-brand-yellow">Cookie Policy</Link>
+          </>
         )}
       </aside>
 
@@ -206,7 +174,7 @@ export default function Sidebar({ items }) {
             >
               <X className="h-6 w-6" />
             </button>
-            <div className="border border-brand-yellow text-brand-yellow rounded p-3 text-center text-xs">
+            <div className="border border-brand-yellow text-brand-yellow rounded-lg p-3 text-center text-sm font-medium">
               Upgrade to Pro for <span className="font-bold">$6.99/mo</span>
             </div>
             <nav className="flex flex-col space-y-4">
@@ -245,6 +213,30 @@ export default function Sidebar({ items }) {
                 >
                   {item.icon}
                   <span>{item.label}</span>
+                </Link>
+              ))}
+              <hr className="border-gray-700 my-4" />
+              <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">Resources</h3>
+              {['About','Contact','FAQ','Support'].map(label => (
+                <Link
+                  key={label}
+                  href="#"
+                  onClick={() => setIsMenuOpen(false)}
+                  className="text-sm text-gray-200 hover:text-brand-yellow"
+                >
+                  {label}
+                </Link>
+              ))}
+              <hr className="border-gray-700 my-4" />
+              <h3 className="mb-2 text-xs font-bold uppercase text-gray-400">Legal</h3>
+              {['Privacy Policy','Terms of Service','Cookie Policy'].map(label => (
+                <Link
+                  key={label}
+                  href="#"
+                  onClick={() => setIsMenuOpen(false)}
+                  className="text-sm text-gray-200 hover:text-brand-yellow"
+                >
+                  {label}
                 </Link>
               ))}
             </nav>

--- a/src/components/navigation/Sidebar.jsx
+++ b/src/components/navigation/Sidebar.jsx
@@ -9,8 +9,6 @@ import {
   Users,
   Map,
   BookOpen,
-  ChevronLeft,
-  ChevronRight,
 } from "lucide-react";
 import { useNavbar } from "../../context/NavbarContext";
 
@@ -58,16 +56,6 @@ export default function Sidebar({ items }) {
           isSidebarCollapsed ? "w-16 p-2" : "w-64 p-6"
         }`}
       >
-        <button
-          onClick={() => setIsSidebarCollapsed((c) => !c)}
-          className="self-end p-2 text-gray-200 hover:text-yellow-400"
-        >
-          {isSidebarCollapsed ? (
-            <ChevronRight className="h-5 w-5" />
-          ) : (
-            <ChevronLeft className="h-5 w-5" />
-          )}
-        </button>
         <nav
           className={`flex flex-col mt-4 space-y-4 ${
             isSidebarCollapsed ? "items-center" : ""

--- a/src/context/NavbarContext.js
+++ b/src/context/NavbarContext.js
@@ -15,6 +15,7 @@ export const useNavbar = () => {
 export const NavbarProvider = ({ children }) => {
   const [searchActive, setSearchActive] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [demoType, setDemoType] = useState("pro");
 
   const handleSwitchDemoType = (newType) => {
@@ -26,6 +27,8 @@ export const NavbarProvider = ({ children }) => {
     setSearchActive,
     isMenuOpen,
     setIsMenuOpen,
+    isSidebarCollapsed,
+    setIsSidebarCollapsed,
     demoType,
     setDemoType,
     handleSwitchDemoType,


### PR DESCRIPTION
## Summary
- always render sidebar alongside page content
- shift main content to the right of the sidebar
- keep mobile overlay menu for small screens

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68505e990de48331aabf66352ea72a77